### PR TITLE
Start qemu with 4 cores

### DIFF
--- a/run/dom0-HW.run
+++ b/run/dom0-HW.run
@@ -153,6 +153,6 @@ append_platform_drv_boot_modules
 
 build_boot_image $boot_modules
 
-append qemu_args " -nographic -smp 2"
+append qemu_args " -nographic -smp 4"
 
 if {$skip_run == 0} {run_genode_until forever}


### PR DESCRIPTION
Start dom0-HW with a 4 cores QEMU configuration by default.
Needs https://github.com/argos-research/genode/pull/27